### PR TITLE
Please pull my changes: make "License:" field more standard and rpmlint-friendly.

### DIFF
--- a/share/template.spec
+++ b/share/template.spec
@@ -6,7 +6,7 @@ Version:    %perl_convert_version %{upstream_version}
 Release:    %mkrel 1
 
 Summary:    DISTSUMMARY
-License:    GPL+ or Artistic
+License:    GPLv1+ or Artistic
 Group:      Development/Perl
 Url:        http://search.cpan.org/dist/%{upstream_name}
 Source0:    http://www.cpan.org/modules/by-module/DISTTOPLEVEL/%{upstream_name}-%{upstream_version}.DISTEXTENSION


### PR DESCRIPTION
See:

http://fedoraproject.org/wiki/Packaging/LicensingGuidelines .

License should read "GPLv1+ or Artistic" instead of "GPL+ or Artistic".
rpmlint complained about that.
