### PR TITLE
Use RPM macros for all dirs, instead of assuming the layout under %_topdir

### DIFF
--- a/lib/CPANPLUS/Dist/Mageia.pm
+++ b/lib/CPANPLUS/Dist/Mageia.pm
@@ -22,7 +22,8 @@ use Readonly;
 use Text::Wrap;
 
 
-Readonly my $RPMDIR => do { chomp(my $d=qx[ rpm --eval %_topdir ]); $d; };
+my @RPMSUBDIRS = qw{ build rpm source spec srcrpm };
+my %RPMDIR =  map {do { chomp(my $d=qx[ rpm --eval %_${_}dir ]); $_, $d; }} @RPMSUBDIRS ;
 
 # -- class methods
 
@@ -48,8 +49,8 @@ sub format_available {
     my $flag;
 
     # check rpm tree structure
-    foreach my $subdir ( qw{ BUILD RPMS SOURCES SPECS SRPMS tmp } ) {
-        my $dir = "$RPMDIR/$subdir";
+    foreach my $subdir ( keys %RPMDIR ) {
+        my $dir = "$RPMDIR{$subdir}";
         next if -d $dir;
         error( "missing directory '$dir'" );
         $flag++;
@@ -201,7 +202,7 @@ sub prepare {
     }
 
     # compute & store path of specfile.
-    my $spec = "$RPMDIR/SPECS/$rpmname.spec";
+    my $spec = "$RPMDIR{spec}/$rpmname.spec";
     $status->specpath($spec);
 
     my $vers = $module->version;
@@ -240,7 +241,7 @@ sub prepare {
 
     # copy package.
     my $basename = basename $module->status->fetch;
-    my $tarball = "$RPMDIR/SOURCES/$basename";
+    my $tarball = "$RPMDIR{source}/$basename";
     copy( $module->status->fetch, $tarball );
 
     msg( "specfile for '$distname' written" );
@@ -311,8 +312,8 @@ sub create {
 
         # check if the dry-run finished correctly
         if ( $success ) {
-            my ($rpm)  = (sort glob "$RPMDIR/RPMS/*/$rpmname-*.rpm")[0];
-            my ($srpm) = (sort glob "$RPMDIR/SRPMS/$rpmname-*.src.rpm")[-1];
+            my ($rpm)  = (sort glob "$RPMDIR{rpm}/*/$rpmname-*.rpm")[0];
+            my ($srpm) = (sort glob "$RPMDIR{srcrpm}/$rpmname-*.src.rpm")[-1];
             msg( "rpm created successfully: $rpm" );
             msg( "srpm available: $srpm" );
             # c::d::mga store
@@ -405,7 +406,7 @@ sub install {
 # 
 sub _has_been_build {
     my ($self, $name, $vers) = @_;
-    my $pkg = ( sort glob "$RPMDIR/RPMS/*/$name-$vers-*.rpm" )[-1];
+    my $pkg = ( sort glob "$RPMDIR{rpm}/*/$name-$vers-*.rpm" )[-1];
     return $pkg;
     # FIXME: should we check cooker?
 }


### PR DESCRIPTION
Before this change, CPANPLUS::Dist::Mageia assumes there will be a
layout %{_topdir}/{BUILD,RPMS,SOURCES,SPECS,SRPMS,tmp}, but rpm allows and
supports customisation of all of these locations via the macros:
- %{_builddir}
- %{_rpmdir}
- %{_sourcesdir}
- %{_specdir
- %{_srpmsdir}
- %{_tmppath}

If the directory layout CPANPLUS::Dist::Mageia expects does not exist,
the error:
[ERROR] Format 'CPANPLUS::Dist::Mageia' is not available
even though the subsequent rpmbuild commands would work.

This patch corrects that, by using the locations for _builddir, _rpmdir,
_sourcesdir, _specdir, and _srpmsdir. _tmppath is not strictly required,
since the %buildroot macro is created from _builddir.

It is debateable whether _builddir should be added or not, as the module
itself does not write or read any files from the location built from
this macro (as it does for rpm,source,spec,srcrpm).
