### PR TITLE
Convert %makeinstall_std to %make_install ; remove trailing space ; correct typos.

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -1,6 +1,6 @@
 # NAME
 
-CPANPLUS::Dist::Mageia - a cpanplus backend to build mageia rpms
+CPANPLUS::Dist::Mageia - A CPANPLUS backend to build Mageia RPMs
 
 # VERSION
 
@@ -8,18 +8,18 @@ version 2.103
 
 # DESCRIPTION
 
-CPANPLUS::Dist::Mageia is a distribution class to create mageia packages
-from CPAN modules, and all its dependencies. This allows you to have
+CPANPLUS::Dist::Mageia is a distribution class to create Mageia packages
+from CPAN modules, and all of their dependencies. This allows you to have
 the most recent copies of CPAN modules installed, using your package
 manager of choice, but without having to wait for central repositories
 to be updated.
 
 You can either install them using the API provided in this package, or
-manually via rpm.
+manually via the `rpm` command.
 
 Some of the bleading edge CPAN modules have already been turned into
-mageia packages for you, and you can make use of them by adding the
-cooker repositories (main & contrib).
+Mageia packages for you, and you can make use of them by adding the
+Cauldron repositories (“core/release”).
 
 Note that these packages are built automatically from CPAN and are
 assumed to have the same license as perl and come without support.
@@ -32,8 +32,8 @@ Please always refer to the original CPAN package if you have questions.
 Return a boolean indicating whether or not you can use this package to
 create and install modules in your environment.
 
-It will verify if you are on a mageia system, and if you have all the
-necessary components avialable to build your own mageia packages. You
+It will verify if you are on a Mageia system, and if you have all the
+necessary components avialable to build your own Mageia packages. You
 will need at least these dependencies installed: `rpm`, `rpmbuild` and
 `gcc`.
 
@@ -46,23 +46,23 @@ Called automatically whenever you create a new `CPANPLUS::Dist` object.
 
 ## my $bool = $mga->prepare;
 
-Prepares a distribution for creation. This means it will create the rpm
-spec file needed to build the rpm and source rpm. This will also satisfy
+Prepares a distribution for creation. This means it will create the RPM
+`.spec` file needed to build the RPM and source RPM. This will also satisfy
 any prerequisites the module may have.
 
-Note that the spec file will be as accurate as possible. However, some
-fields may wrong (especially the description, and maybe the summary)
-since it relies on pod parsing to find those information.
+Note that the .spec file will be as accurate as possible. However, some
+fields may be wrong (especially the description, and maybe the summary)
+since it relies on parsing POD to find this information.
 
 Returns true on success and false on failure.
 
-You may then call `$mga->create` on the object to create the rpm
+You may then call `$mga->create` on the object to create the RPM
 from the spec file, and then `$mga->install` on the object to
 actually install it.
 
 ## my $bool = $mga->create;
 
-Builds the rpm file from the spec file created during the `create()`
+Builds the RPM file from the spec file created during the `create()`
 step.
 
 Returns true on success and false on failure.
@@ -71,7 +71,7 @@ You may then call `$mga->install` on the object to actually install it.
 
 ## my $bool = $mga->install;
 
-Installs the rpm using `rpm -U`. If run as a non-root user, uses
+Installs the RPM using `rpm -U`. If run as a non-root user, uses
 `sudo`. This assumes that current user has sudo rights (without
 password for max efficiency) to run `rpm`.
 
@@ -91,8 +91,8 @@ really be probed rather than assumed.
 
 ## Long description
 
-Right now we provided the description as given by the module in it's
-meta data. However, not all modules provide this meta data and rather
+Right now we provide the description as given by the module in its
+meta-data. However, not all modules provide this meta-data and rather
 than scanning the files in the package for it, we simply default to the
 name of the module.
 

--- a/README.mkdn
+++ b/README.mkdn
@@ -4,7 +4,7 @@ CPANPLUS::Dist::Mageia - a cpanplus backend to build mageia rpms
 
 # VERSION
 
-version 2.102
+version 2.103
 
 # DESCRIPTION
 

--- a/README.mkdn
+++ b/README.mkdn
@@ -6,6 +6,10 @@ CPANPLUS::Dist::Mageia - A CPANPLUS backend to build Mageia RPMs
 
 version 2.103
 
+# SYNOPSIS
+
+    $ cpan2dist --format=CPANPLUS::Dist::Mageia Some::Random::Package
+
 # DESCRIPTION
 
 CPANPLUS::Dist::Mageia is a distribution class to create Mageia packages
@@ -76,10 +80,6 @@ Installs the RPM using `rpm -U`. If run as a non-root user, uses
 password for max efficiency) to run `rpm`.
 
 Returns true on success and false on failure
-
-# SYNOPSYS
-
-    $ cpan2dist --format=CPANPLUS::Dist::Mageia Some::Random::Package
 
 # TODO
 

--- a/dist.ini
+++ b/dist.ini
@@ -6,4 +6,4 @@ copyright_year   = 2011
 
 [@Author::JQUELIN]
 [Test::TrailingSpace]
-filename_regex = (?:(?:\.(?:t|pm|pl|PL|yml|json|arc|vim|mkdn))|README|Changes)\z
+filename_regex = (?:(?:\.(?:t|pm|pl|PL|yml|json|arc|vim|mkdn))|README(?:\.[^/]*)?|Changes)\z

--- a/lib/CPANPLUS/Dist/Mageia.pm
+++ b/lib/CPANPLUS/Dist/Mageia.pm
@@ -150,7 +150,7 @@ sub prepare {
         push @reqs, 'Module::Build::Compat' if _is_module_build_compat($module);
         $distbuild = "%{__perl} Makefile.PL INSTALLDIRS=vendor\n";
         $distmaker = "%make";
-        $distinstall = "%makeinstall_std";
+        $distinstall = "%make_install";
     } else {
         # module::build only distribution
         # The double dashes ("--") are for Module::Build::Tiny compatibility:

--- a/lib/CPANPLUS/Dist/Mageia.pm
+++ b/lib/CPANPLUS/Dist/Mageia.pm
@@ -561,7 +561,7 @@ sub _module_summary {
 __END__
 
 
-=head1 SYNOPSYS
+=head1 SYNOPSIS
 
     $ cpan2dist --format=CPANPLUS::Dist::Mageia Some::Random::Package
 

--- a/lib/CPANPLUS/Dist/Mageia.pm
+++ b/lib/CPANPLUS/Dist/Mageia.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 
 package CPANPLUS::Dist::Mageia;
-# ABSTRACT: a cpanplus backend to build mageia rpms
+# ABSTRACT: A CPANPLUS backend to build Mageia RPMs
 
 use base 'CPANPLUS::Dist::Base';
 
@@ -32,8 +32,8 @@ my %RPMDIR =  map {do { chomp(my $d=qx[ rpm --eval %_${_}dir ]); $_, $d; }} @RPM
 Return a boolean indicating whether or not you can use this package to
 create and install modules in your environment.
 
-It will verify if you are on a mageia system, and if you have all the
-necessary components avialable to build your own mageia packages. You
+It will verify if you are on a Mageia system, and if you have all the
+necessary components avialable to build your own Mageia packages. You
 will need at least these dependencies installed: C<rpm>, C<rpmbuild> and
 C<gcc>.
 
@@ -98,17 +98,17 @@ sub init {
 
 =method my $bool = $mga->prepare;
 
-Prepares a distribution for creation. This means it will create the rpm
-spec file needed to build the rpm and source rpm. This will also satisfy
+Prepares a distribution for creation. This means it will create the RPM
+C<.spec> file needed to build the RPM and source RPM. This will also satisfy
 any prerequisites the module may have.
 
-Note that the spec file will be as accurate as possible. However, some
-fields may wrong (especially the description, and maybe the summary)
-since it relies on pod parsing to find those information.
+Note that the .spec file will be as accurate as possible. However, some
+fields may be wrong (especially the description, and maybe the summary)
+since it relies on parsing POD to find this information.
 
 Returns true on success and false on failure.
 
-You may then call C<< $mga->create >> on the object to create the rpm
+You may then call C<< $mga->create >> on the object to create the RPM
 from the spec file, and then C<< $mga->install >> on the object to
 actually install it.
 
@@ -256,7 +256,7 @@ sub prepare {
 
 =method my $bool = $mga->create;
 
-Builds the rpm file from the spec file created during the C<create()>
+Builds the RPM file from the spec file created during the C<create()>
 step.
 
 Returns true on success and false on failure.
@@ -351,7 +351,7 @@ sub create {
 
 =method my $bool = $mga->install;
 
-Installs the rpm using C<rpm -U>. If run as a non-root user, uses
+Installs the RPM using C<rpm -U>. If run as a non-root user, uses
 C<sudo>. This assumes that current user has sudo rights (without
 password for max efficiency) to run C<rpm>.
 
@@ -569,18 +569,18 @@ __END__
 
 =head1 DESCRIPTION
 
-CPANPLUS::Dist::Mageia is a distribution class to create mageia packages
-from CPAN modules, and all its dependencies. This allows you to have
+CPANPLUS::Dist::Mageia is a distribution class to create Mageia packages
+from CPAN modules, and all of their dependencies. This allows you to have
 the most recent copies of CPAN modules installed, using your package
 manager of choice, but without having to wait for central repositories
 to be updated.
 
 You can either install them using the API provided in this package, or
-manually via rpm.
+manually via the C<rpm> command.
 
 Some of the bleading edge CPAN modules have already been turned into
-mageia packages for you, and you can make use of them by adding the
-cooker repositories (main & contrib).
+Mageia packages for you, and you can make use of them by adding the
+Cauldron repositories (“core/release”).
 
 Note that these packages are built automatically from CPAN and are
 assumed to have the same license as perl and come without support.
@@ -600,8 +600,8 @@ really be probed rather than assumed.
 
 =head2 Long description
 
-Right now we provided the description as given by the module in it's
-meta data. However, not all modules provide this meta data and rather
+Right now we provide the description as given by the module in its
+meta-data. However, not all modules provide this meta-data and rather
 than scanning the files in the package for it, we simply default to the
 name of the module.
 


### PR DESCRIPTION
Hi @jquelin !

Please rebase and release:

Convert %makeinstall_std to %make_install ; remove trailing space ; correct typos.